### PR TITLE
Quick fix to solve "no internet connection"

### DIFF
--- a/Luxinate.py
+++ b/Luxinate.py
@@ -820,7 +820,7 @@ class Luxinate():
     """
     def hasConnection(self):
         try:
-            urllib2.urlopen('http://74.125.228.100', timeout = 1)
+            urllib2.urlopen('http://google.com', timeout = 1)
             return True
         except urllib2.URLError:
             pass


### PR DESCRIPTION
Switched hasConnection’s baseline from one google IP to simply
google.com, which should almost always be a more accurate test as to
internet connection.
